### PR TITLE
feat: update evaluation dashboard with namespace variable

### DIFF
--- a/dashboards/Flipt/flipt-evaluations.json
+++ b/dashboards/Flipt/flipt-evaluations.json
@@ -25,7 +25,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 2,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -112,7 +111,7 @@
             "uid": "flipt_prometheus"
           },
           "editorMode": "builder",
-          "expr": "rate(flipt_evaluations_requests_total{flag=\"$flag_key\"}[$__rate_interval])",
+          "expr": "rate(flipt_evaluations_requests_total{flag=\"$flag_key\", namespace=\"$namespace\"}[$__rate_interval])",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -204,7 +203,7 @@
             "uid": "flipt_prometheus"
           },
           "editorMode": "builder",
-          "expr": "rate(flipt_evaluations_results_total{flag=\"$flag_key\"}[$__rate_interval])",
+          "expr": "rate(flipt_evaluations_results_total{flag=\"$flag_key\", namespace=\"$namespace\"}[$__rate_interval])",
           "legendFormat": "Match: {{match}} Reason: {{reason}} Segment: {{segment}} Value: {{value}}",
           "range": true,
           "refId": "A"
@@ -283,7 +282,7 @@
             "uid": "flipt_prometheus"
           },
           "editorMode": "builder",
-          "expr": "rate(flipt_evaluations_latency_milliseconds_bucket{flag=\"$flag_key\"}[$__rate_interval])",
+          "expr": "rate(flipt_evaluations_latency_milliseconds_bucket{flag=\"$flag_key\", namespace=\"$namespace\"}[$__rate_interval])",
           "format": "heatmap",
           "legendFormat": "{{le}}",
           "range": true,
@@ -302,8 +301,8 @@
       {
         "current": {
           "selected": false,
-          "text": "foo",
-          "value": "foo"
+          "text": "color",
+          "value": "color"
         },
         "datasource": {
           "type": "prometheus",
@@ -324,17 +323,43 @@
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "experiment",
+          "value": "experiment"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "flipt_prometheus"
+        },
+        "definition": "label_values(flipt_evaluations_results_total, namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "label_values(flipt_evaluations_results_total, namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
       }
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-3h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Flipt Flag Evaluations",
   "uid": "0uevD0OVz",
-  "version": 3,
+  "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
Fixes FLI-283

This adds namespaces to the evaluations dashboard.
This is required to observe all flags in the system.
Since names are now only unique per namespace.

<img width="1659" alt="Screenshot 2023-04-03 at 14 26 46" src="https://user-images.githubusercontent.com/1253326/229523960-ef6d393a-9f02-4105-a42c-a454b680e855.png">
